### PR TITLE
CIoU Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Without autograd
 
 - [x] `box_iou`
 - [x] `generalized_box_iou`
-- [ ] `complete_box_iou`
+- [x] `complete_box_iou`
 - [x] `distance_box_iou`
 
 ### Loss Operations
@@ -125,7 +125,7 @@ Obviously this has to have autograd
 
 - [x] `_loss_inter_union`
 - [x] `generalized_box_iou_loss`
-- [ ] `completed_box_iou_loss`
+- [x] `complete_box_iou_loss`
 - [x] `distance_box_iou_loss`
 - [ ] `minimum_points_distance_loss`
 - [ ] `normalized_wasserstein_distance_loss`

--- a/benchmark/box_iou.py
+++ b/benchmark/box_iou.py
@@ -9,6 +9,7 @@ import torch
 from torchvision.ops._utils import _loss_inter_union as tv_loss_inter_union
 from torchvision.ops.boxes import box_area as tv_box_area
 from torchvision.ops.boxes import box_iou as tv_box_iou
+from torchvision.ops.ciou_loss import complete_box_iou_loss as tv_complete_box_iou_loss
 from torchvision.ops.diou_loss import distance_box_iou_loss as tv_distance_box_iou_loss
 from torchvision.ops.giou_loss import (
     generalized_box_iou_loss as tv_generalized_box_iou_loss,
@@ -17,6 +18,7 @@ from torchvision.ops.giou_loss import (
 from torch_fast_box_ops import _loss_inter_union as tfbo_loss_inter_union
 from torch_fast_box_ops import box_area as tfbo_box_area
 from torch_fast_box_ops import box_iou as tfbo_box_iou
+from torch_fast_box_ops import complete_box_iou_loss as tfbo_complete_box_iou_loss
 from torch_fast_box_ops import distance_box_iou_loss as tfbo_distance_box_iou_loss
 from torch_fast_box_ops import generalized_box_iou_loss as tfbo_generalized_box_iou_loss
 
@@ -140,10 +142,13 @@ def benchmark_box_iou_loss(
     tfbo_fn = {
         "giou": tfbo_generalized_box_iou_loss,
         "diou": tfbo_distance_box_iou_loss,
+        "ciou": tfbo_complete_box_iou_loss,
     }[iou_type]
-    tv_fn = {"giou": tv_generalized_box_iou_loss, "diou": tv_distance_box_iou_loss}[
-        iou_type
-    ]
+    tv_fn = {
+        "giou": tv_generalized_box_iou_loss,
+        "diou": tv_distance_box_iou_loss,
+        "ciou": tv_complete_box_iou_loss,
+    }[iou_type]
 
     # Warm-up
     _ = tfbo_fn(boxes1, boxes2)
@@ -214,6 +219,13 @@ def run_benchmarks():
         no_int32_dtypes,
         "Distance Box IoU Loss",
         functools.partial(benchmark_box_iou_loss, iou_type="diou"),
+    )
+
+    run_benchmark(
+        devices,
+        no_int32_dtypes,
+        "Complete Box IoU Loss",
+        functools.partial(benchmark_box_iou_loss, iou_type="ciou"),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ profile = "black"
 
 [project]
 name = "torch-fast-box-ops"
-version = "0.0.2"
+version = "0.0.3"
 description = "Pytorch Faster Box Operations"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 """Compile the C++ and CUDA extensions for torch_fast_box_ops."""
 from pathlib import Path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 if __name__ == "__main__":

--- a/test/test_box_convert.py
+++ b/test/test_box_convert.py
@@ -2,13 +2,11 @@ import pytest
 import torch
 from torch import Tensor
 from torch.nn import functional as F
+from torchvision.ops import complete_box_iou_loss, generalized_box_iou_loss
 from torchvision.ops.boxes import box_convert as tv_box_convert
-from torchvision.ops import generalized_box_iou_loss, complete_box_iou_loss
+from utils import make_random_boxes
 
 from torch_fast_box_ops import box_convert as tfbo_box_convert
-
-
-from utils import make_random_boxes
 
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])

--- a/test/test_box_iou.py
+++ b/test/test_box_iou.py
@@ -8,6 +8,7 @@ from torchvision.ops.boxes import (
     box_iou as tv_box_iou,
     generalized_box_iou as tv_generalized_box_iou,
     distance_box_iou as tv_distance_box_iou,
+    complete_box_iou as tv_complete_box_iou,
 )
 from torchvision.ops.giou_loss import (
     generalized_box_iou_loss as tv_generalized_box_iou_loss,
@@ -22,6 +23,7 @@ from torch_fast_box_ops import (
     generalized_box_iou_loss as tfbo_generalized_box_iou_loss,
     distance_box_iou as tfbo_distance_box_iou,
     distance_box_iou_loss as tfbo_distance_box_iou_loss,
+    complete_box_iou as tfbo_complete_box_iou,
 )
 
 from utils import make_random_boxes, make_random_box_pairs
@@ -160,6 +162,23 @@ def test_box_diou(device: str, num_batch: int, dtype: torch.dtype, num_boxes: tu
         num_boxes,
         tfbo_distance_box_iou,
         tv_distance_box_iou,
+    )
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("num_batch", [1, 4])
+@pytest.mark.parametrize(
+    "dtype", [torch.float32, torch.float64, torch.float16, torch.int32]
+)
+@pytest.mark.parametrize("num_boxes", [(10, 12), (31, 32), (91, 318)])
+def test_box_ciou(device: str, num_batch: int, dtype: torch.dtype, num_boxes: tuple):
+    run_box_iou_test(
+        device,
+        num_batch,
+        dtype,
+        num_boxes,
+        tfbo_complete_box_iou,
+        tv_complete_box_iou,
     )
 
 

--- a/test/test_box_iou.py
+++ b/test/test_box_iou.py
@@ -3,30 +3,28 @@ from typing import Callable
 import pytest
 import torch
 from torch.nn import functional as F
-from torchvision.ops.boxes import (
-    box_area as tv_box_area,
-    box_iou as tv_box_iou,
-    generalized_box_iou as tv_generalized_box_iou,
-    distance_box_iou as tv_distance_box_iou,
-    complete_box_iou as tv_complete_box_iou,
-)
+from torchvision.ops._utils import _loss_inter_union as tv_loss_inter_union
+from torchvision.ops.boxes import box_area as tv_box_area
+from torchvision.ops.boxes import box_iou as tv_box_iou
+from torchvision.ops.boxes import complete_box_iou as tv_complete_box_iou
+from torchvision.ops.boxes import distance_box_iou as tv_distance_box_iou
+from torchvision.ops.boxes import generalized_box_iou as tv_generalized_box_iou
+from torchvision.ops.ciou_loss import complete_box_iou_loss as tv_complete_box_iou_loss
+from torchvision.ops.diou_loss import distance_box_iou_loss as tv_distance_box_iou_loss
 from torchvision.ops.giou_loss import (
     generalized_box_iou_loss as tv_generalized_box_iou_loss,
 )
-from torchvision.ops.diou_loss import distance_box_iou_loss as tv_distance_box_iou_loss
-from torchvision.ops._utils import _loss_inter_union as tv_loss_inter_union
-from torch_fast_box_ops import (
-    box_area as tfbo_box_area,
-    box_iou as tfbo_box_iou,
-    _loss_inter_union as tfbo_loss_inter_union,
-    generalized_box_iou as tfbo_generalized_box_iou,
-    generalized_box_iou_loss as tfbo_generalized_box_iou_loss,
-    distance_box_iou as tfbo_distance_box_iou,
-    distance_box_iou_loss as tfbo_distance_box_iou_loss,
-    complete_box_iou as tfbo_complete_box_iou,
-)
+from utils import make_random_box_pairs, make_random_boxes
 
-from utils import make_random_boxes, make_random_box_pairs
+from torch_fast_box_ops import _loss_inter_union as tfbo_loss_inter_union
+from torch_fast_box_ops import box_area as tfbo_box_area
+from torch_fast_box_ops import box_iou as tfbo_box_iou
+from torch_fast_box_ops import complete_box_iou as tfbo_complete_box_iou
+from torch_fast_box_ops import complete_box_iou_loss as tfbo_complete_box_iou_loss
+from torch_fast_box_ops import distance_box_iou as tfbo_distance_box_iou
+from torch_fast_box_ops import distance_box_iou_loss as tfbo_distance_box_iou_loss
+from torch_fast_box_ops import generalized_box_iou as tfbo_generalized_box_iou
+from torch_fast_box_ops import generalized_box_iou_loss as tfbo_generalized_box_iou_loss
 
 IouFn = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 
@@ -285,3 +283,8 @@ def test_loss_giou_backward(device: torch.device):
 @pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
 def test_loss_diou_backward(device: torch.device):
     _test_backward_box_iou(tfbo_distance_box_iou_loss, tv_distance_box_iou_loss, device)
+
+
+@pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
+def test_loss_ciou_backward(device: torch.device):
+    _test_backward_box_iou(tfbo_complete_box_iou_loss, tv_complete_box_iou_loss, device)

--- a/torch_fast_box_ops/__init__.py
+++ b/torch_fast_box_ops/__init__.py
@@ -144,6 +144,19 @@ def generalized_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
 
 
 def distance_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
+    """Compute the Distance Intersection over Union (DIoU) for two sets of bounding boxes.
+
+    Args:
+        boxes1 (Tensor): First set of M boxes in format [x1, y1, x2, y2].
+        boxes2 (Tensor): Second set of N boxes in format [x1, y1, x2, y2].
+
+    Returns:
+        Tensor: [M, N] DIoU values for each pair of boxes.
+    """
+    return torch.ops.box_ops.distance_box_iou(boxes1.contiguous(), boxes2.contiguous())
+
+
+def complete_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     """Compute the Complete Intersection over Union (CIoU) for two sets of bounding boxes.
 
     Args:
@@ -153,7 +166,7 @@ def distance_box_iou(boxes1: Tensor, boxes2: Tensor) -> Tensor:
     Returns:
         Tensor: [M, N] CIoU values for each pair of boxes.
     """
-    return torch.ops.box_ops.distance_box_iou(boxes1.contiguous(), boxes2.contiguous())
+    return torch.ops.box_ops.complete_box_iou(boxes1.contiguous(), boxes2.contiguous())
 
 
 def _box_iou_loss_context(

--- a/torch_fast_box_ops/boxes.cuh
+++ b/torch_fast_box_ops/boxes.cuh
@@ -2,6 +2,8 @@
 
 #include <ATen/Dispatch.h>
 
+#include "kernel.cuh"
+
 template<typename T> struct box_aligned_size
 {
     static constexpr size_t value = sizeof(T) * 4;
@@ -44,6 +46,10 @@ template<typename T> struct alignas(box_aligned_size<T>::value) XYXY
         };
         typename aligned_type<T, 4>::vec_t vec;// maps to float4, int4, etc.
     };
+
+    [[nodiscard]] TFBO_HOST_DEVICE auto width() const noexcept -> T { return x2 - x1; }
+
+    [[nodiscard]] TFBO_HOST_DEVICE auto height() const noexcept -> T { return y2 - y1; }
 };
 
 template<typename T> struct alignas(box_aligned_size<T>::value) XYWH

--- a/torch_fast_box_ops/common.cpp
+++ b/torch_fast_box_ops/common.cpp
@@ -13,6 +13,7 @@ TORCH_LIBRARY(box_ops, m)
     m.def("box_iou(Tensor boxes1, Tensor boxes2) -> Tensor");
     m.def("generalized_box_iou(Tensor boxes1, Tensor boxes2) -> Tensor");
     m.def("distance_box_iou(Tensor boxes1, Tensor boxes2) -> Tensor");
+    m.def("complete_box_iou(Tensor boxes1, Tensor boxes2) -> Tensor");
 
     // IoU Loss operations fn(N,N)->N, has backward
     m.def("_loss_inter_union(Tensor boxes1, Tensor boxes2) -> (Tensor, Tensor)");

--- a/torch_fast_box_ops/common.cpp
+++ b/torch_fast_box_ops/common.cpp
@@ -27,4 +27,7 @@ TORCH_LIBRARY(box_ops, m)
 
     m.def("distance_box_iou_loss(Tensor boxes1, Tensor boxes2, float eps) -> Tensor");
     m.def("distance_box_iou_loss_backward(Tensor grad, Tensor boxes1, Tensor boxes2, float eps) -> (Tensor, Tensor)");
+
+    m.def("complete_box_iou_loss(Tensor boxes1, Tensor boxes2, float eps) -> Tensor");
+    m.def("complete_box_iou_loss_backward(Tensor grad, Tensor boxes1, Tensor boxes2, float eps) -> (Tensor, Tensor)");
 }

--- a/torch_fast_box_ops/iou.cu
+++ b/torch_fast_box_ops/iou.cu
@@ -89,11 +89,8 @@ auto TFBO_HOST_DEVICE box_iou_fn(const XYXY<In> &box1, const In area1, const XYX
         if constexpr (std::is_same_v<IouType, diou_tag>) {
             return diou;
         } else {
-            const auto box1_w = box1.x2 - box1.x1;
-            const auto box1_h = box1.y2 - box1.y1;
-            const auto box2_w = box2.x2 - box2.x1;
-            const auto box2_h = box2.y2 - box2.y1;
-            const auto aspect = std::atan(box1_w / (box1_h + 1e-7)) - std::atan(box2_w / (box2_h + 1e-7));
+            const auto aspect =
+                std::atan(box1.width() / (box1.height() + 1e-7)) - std::atan(box2.width() / (box2.height() + 1e-7));
             const auto v = (4 / (M_PI * M_PI)) * aspect * aspect;
             const auto alpha = v / (1 - iou + v + 1e-7);
             return diou - alpha * v;

--- a/torch_fast_box_ops/iou.cu
+++ b/torch_fast_box_ops/iou.cu
@@ -72,19 +72,32 @@ auto TFBO_HOST_DEVICE box_iou_fn(const XYXY<In> &box1, const In area1, const XYX
 {
     const In intersection = box_intersection_area(box1, box2);
     const Out union_area = area1 + area2 - intersection;
+    const Out iou = intersection / union_area;
     if constexpr (std::is_same_v<IouType, iou_tag>) {
         return intersection / union_area;
     } else if constexpr (std::is_same_v<IouType, giou_tag>) {
         XYXY<In> enclosing_box = min_enclosing_box(box1, box2);
         Out enclosing_area = std::max(box_area_op(enclosing_box), static_cast<In>(0));
-        return intersection / union_area - (enclosing_area - union_area) / enclosing_area;
-    } else if constexpr (std::is_same_v<IouType, diou_tag>) {
+        return iou - (enclosing_area - union_area) / enclosing_area;
+    } else if constexpr (std::is_same_v<IouType, diou_tag> || std::is_same_v<IouType, ciou_tag>) {
         XYXY<In> enclosing_box = min_enclosing_box(box1, box2);
         const Out diag_dist_sq = dist_sq<Out>(enclosing_box.x2 - enclosing_box.x1, enclosing_box.y2 - enclosing_box.y1);
         const CXCY<Out> box1c(box1);
         const CXCY<Out> box2c(box2);
         const Out cent_dist_sq = dist_sq<Out>(box1c.cx - box2c.cx, box1c.cy - box2c.cy);
-        return intersection / union_area - cent_dist_sq / (diag_dist_sq + static_cast<Out>(1e-7));
+        const auto diou = iou - cent_dist_sq / (diag_dist_sq + static_cast<Out>(1e-7));
+        if constexpr (std::is_same_v<IouType, diou_tag>) {
+            return diou;
+        } else {
+            const auto box1_w = box1.x2 - box1.x1;
+            const auto box1_h = box1.y2 - box1.y1;
+            const auto box2_w = box2.x2 - box2.x1;
+            const auto box2_h = box2.y2 - box2.y1;
+            const auto aspect = std::atan(box1_w / (box1_h + 1e-7)) - std::atan(box2_w / (box2_h + 1e-7));
+            const auto v = (4 / (M_PI * M_PI)) * aspect * aspect;
+            const auto alpha = v / (1 - iou + v + 1e-7);
+            return diou - alpha * v;
+        }
     }
 }
 
@@ -204,7 +217,7 @@ void box_iou_gpu_impl(const torch::Tensor &boxes1, const torch::Tensor &boxes2, 
     });
 }
 
-auto regularize_for_iou(const torch::Tensor &boxes1, const torch::Tensor &boxes2, const torch::Tensor &output)
+auto regularize_shape_for_iou(const torch::Tensor &boxes1, const torch::Tensor &boxes2, const torch::Tensor &output)
     -> std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
 {
     torch::Tensor boxes1_flat, boxes2_flat, output_flat;
@@ -247,7 +260,7 @@ template<typename IouType> auto box_iou(const torch::Tensor &boxes1, const torch
 
     // Regularize the shape to Batch x Nboxes x 4
     torch::Tensor boxes1_flat, boxes2_flat, output_flat;
-    std::tie(boxes1_flat, boxes2_flat, output_flat) = regularize_for_iou(boxes1, boxes2, output);
+    std::tie(boxes1_flat, boxes2_flat, output_flat) = regularize_shape_for_iou(boxes1, boxes2, output);
 
     if (boxes1_flat.is_cuda()) {
         box_iou_gpu_impl<IouType>(boxes1_flat, boxes2_flat, output_flat);
@@ -265,6 +278,8 @@ TORCH_LIBRARY_IMPL(box_ops, CPU, m)
     m.impl("box_iou", &box_iou<iou_tag>);
     m.impl("generalized_box_iou", &box_iou<giou_tag>);
     m.impl("distance_box_iou", &box_iou<diou_tag>);
+    m.impl("complete_box_iou", &box_iou<ciou_tag>);
+
     m.impl("box_area_backward", &box_area_backward);
 }
 
@@ -274,5 +289,7 @@ TORCH_LIBRARY_IMPL(box_ops, CUDA, m)
     m.impl("box_iou", &box_iou<iou_tag>);
     m.impl("generalized_box_iou", &box_iou<giou_tag>);
     m.impl("distance_box_iou", &box_iou<diou_tag>);
+    m.impl("complete_box_iou", &box_iou<ciou_tag>);
+
     m.impl("box_area_backward", &box_area_backward);
 }

--- a/torch_fast_box_ops/iou_common.cuh
+++ b/torch_fast_box_ops/iou_common.cuh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "boxes.cuh"
-#include "kernel.cuh"
 
 struct iou_type_tag
 {


### PR DESCRIPTION
Added CIoU implementation with testing.

```text
Complete Box IoU Loss Benchmark Results:
  device          dtype  time_tfbo   time_tv    speedup
0    cpu  torch.float32   0.012334  0.069945   5.670832
1    cpu  torch.float64   0.011918  0.068255   5.726825
2    cpu  torch.float16   0.026843  0.071938   2.679915
3   cuda  torch.float32   0.020995  0.249095  11.864626
4   cuda  torch.float64   0.023138  0.237842  10.279403
5   cuda  torch.float16   0.022223  0.228383  10.276784

Average speedup: 7.74973059342349
```